### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
   <img src="assets/hero_modus_mcp.png" alt="Modus 2 MCP" width="600">
 </div>
 
+<a href="https://glama.ai/mcp/servers/@julianoczkowski/mcp-modus">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@julianoczkowski/mcp-modus/badge" alt="Modus MCP server" />
+</a>
+
 [![NPM Version](https://img.shields.io/npm/v/@julianoczkowski/mcp-modus)](https://www.npmjs.com/package/@julianoczkowski/mcp-modus)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
This PR adds a badge for the [MCP Modus](https://glama.ai/mcp/servers/@julianoczkowski/mcp-modus) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@julianoczkowski/mcp-modus">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@julianoczkowski/mcp-modus/badge" alt="Modus MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.